### PR TITLE
Refactor generate_with_adaptive_compute and implement forward_with_adaptive_compute

### DIFF
--- a/evaluate_raven/eval_alternate_loops.py
+++ b/evaluate_raven/eval_alternate_loops.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+# Add the parent directory to the Python path to make recpre importable
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from evaluate_raven.hf_eval_adaptive_compute import evaluate_single_task
+from recpre.raven_modeling_minimal import NumStepsGenerator
+
+
+if __name__ == "__main__":
+    # simple example demonstrating how to use the exit evaluator
+    exit_evaluator = NumStepsGenerator(lambda x: 4 if x % 2 == 0 else 8)
+
+    task = "hellaswag"
+    batch_size = 1
+    max_steps = 8
+    
+    evaluate_single_task(
+        task_name=task,
+        batch_size=batch_size,
+        num_steps=max_steps,
+        num_fewshot=0,
+        exit_evaluator=exit_evaluator,
+        limit=100,
+        output_filepath=f"{task}_results_48.json",
+    )


### PR DESCRIPTION
This PR consists of 3 commits. 

# Commit 1
The first commit refactors the existing generate_with_adaptive_compute implementation, abstracting out "ExitEvaluator"s. The goal of this refactor is to maintain functional parity. To test this change, I have verified with a simple test script, comparing the new and old implementation results.
```
def old_generate_with_adaptive_compute(

...

def compare_adaptive_compute(model: RavenForCausalLM, input_ids: torch.Tensor, criterion: str):
    init_scale = 0 # lock initial scale to 0 to have deterministic results
    generation_config = GenerationConfig(
        max_length=64,
        use_cache=True,
        pad_token_id=model.config.pad_token_id,
        return_dict_in_generate=True,
        do_sample=False,
    )
    new_output = model.generate_with_adaptive_compute(
        input_ids=input_ids,
        criterion=criterion,
        init_scale=0,
        generation_config=generation_config,
    )
    old_output = old_generate_with_adaptive_compute(
        model,
        input_ids=input_ids,
        criterion=criterion,
        init_scale=0,
        generation_config=generation_config,
    )
    assert(isinstance(new_output, GenerateDecoderOnlyOutput) and isinstance(old_output, GenerateDecoderOnlyOutput))
    assert torch.equal(new_output.sequences, old_output.sequences)
    assert new_output.scores == old_output.scores
    print(f"Criterion: {criterion} passed")


def test_adaptive_compute():
    model: RavenForCausalLM = AutoModelForCausalLM.from_pretrained("tomg-group-umd/huginn-0125", trust_remote_code=True)
    model.to("cuda", dtype=torch.bfloat16)

    model.eval()

    tokenizer = AutoTokenizer.from_pretrained("tomg-group-umd/huginn-0125")
    test_input = tokenizer.encode("Hello world")
    input_ids = torch.tensor([test_input]).to("cuda")

    for criterion in ["entropy-diff", "latent-diff", "minp-kl", "argmax-stability"]:
        print(f"Testing criterion: {criterion}")
        compare_adaptive_compute(model, input_ids, criterion)


if __name__ == "__main__":
    test_adaptive_compute()
```

# Commit 2 and 3
The following 2 commits implement an Auto-Regressive style forward pass. While inefficient, the purpose is to compute logits with adaptive compute steps, so we can run loglikelihood benchmarks like ARC-E and hellaswag.

As proof that this auto-regressive style forward works, I have tested with using a constant number `NumStepsGenerator` that always returns 8, and then compared with running the normal forward pass. While there were some minor numerical differences likely caused by different underlying matrix algorithms, the results mostly matched.