### PR TITLE
Add option to prefill adaptively with generate_with_adaptive_compute

### DIFF
--- a/evaluate_raven/misc_benchmark_variants/eval_alternate_loops.py
+++ b/evaluate_raven/misc_benchmark_variants/eval_alternate_loops.py
@@ -4,7 +4,7 @@ import sys
 # Add the parent directory to the Python path to make recpre importable
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-from evaluate_raven.hf_eval_adaptive_compute import evaluate_single_task
+from evaluate_raven.misc_benchmark_variants.hf_eval_adaptive_compute import evaluate_tasks
 from recpre.raven_modeling_minimal import NumStepsGenerator
 
 
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     batch_size = 1
     max_steps = 8
 
-    evaluate_single_task(
+    evaluate_tasks(
         task_name=task,
         batch_size=batch_size,
         num_steps=max_steps,

--- a/evaluate_raven/misc_benchmark_variants/hf_eval_adaptive_compute.py
+++ b/evaluate_raven/misc_benchmark_variants/hf_eval_adaptive_compute.py
@@ -2,6 +2,7 @@
 you should probably just use lm-eval.
 """
 
+from datetime import datetime
 from pathlib import Path
 from typing import Literal, Optional, Union
 import os
@@ -21,7 +22,7 @@ from lm_eval.models.huggingface import HFLM
 
 
 from recpre.raven_modeling_minimal import RavenForCausalLM, CausalLMOutputRecurrentLatents
-from recpre.raven_modeling_minimal import PerIterationExitEvaluator
+from recpre.raven_modeling_minimal import PerIterationExitEvaluator, SupportedExitCriteria
 from evaluate_raven.quick_checkpoint_eval import prepare_results
 
 
@@ -51,9 +52,8 @@ class HuginnWrapper(HFLM):
         pretrained: Union[str, transformers.PreTrainedModel],
         *,
         backend: Literal["default", "causal", "seq2seq"] = "default",
-        criterion: Optional[Literal["entropy-diff", "latent-diff", "minp-kl", "argmax-stability", "none"]] = "entropy-diff",
-        exit_threshold: Optional[Union[str, float, int]] = "auto",
-        lookup_strategy: str = "full",
+        criterion: Literal["entropy-diff", "latent-diff", "cosine", "minp-kl", "kl", "argmax-stability", "none"] = "entropy-diff",
+        exit_threshold: Union[str, float, int] = "auto",
         continuous_compute: bool = False,
         exit_evaluator: Optional[PerIterationExitEvaluator] = None,
         prefill_with_varied_exit_steps: bool = False,
@@ -120,7 +120,6 @@ class HuginnWrapper(HFLM):
         )
         self.criterion = criterion
         self.exit_threshold = exit_threshold
-        self.lookup_strategy = lookup_strategy
         self.continuous_compute = continuous_compute
         self.exit_evaluator = exit_evaluator
         self.prefill_with_varied_exit_steps = prefill_with_varied_exit_steps
@@ -137,19 +136,28 @@ class HuginnWrapper(HFLM):
             pad_token_id=self.tokenizer.pad_token_id,
             return_dict_in_generate=True,
         )
-        output = super()._model_generate(
-            context,
-            max_length,
-            stop,
-            generation_config=generation_config,
-            criterion=self.criterion,
-            exit_threshold=self.exit_threshold,
-            cache_kwargs={"lookup_strategy": self.lookup_strategy},
-            continuous_compute=self.continuous_compute,
-            exit_evaluator=self.exit_evaluator,
-            prefill_with_varied_exit_steps=self.prefill_with_varied_exit_steps,
-            **generation_kwargs,
-        )
+        if (self.criterion == SupportedExitCriteria.NONE.value or self.exit_threshold == "none") and self.exit_evaluator is None:
+            output = super()._model_generate(
+                context,
+                max_length,
+                stop,
+                generation_config=generation_config,
+                continuous_compute=self.continuous_compute,
+                **generation_kwargs,
+            )
+        else:
+            output = super()._model_generate(
+                context,
+                max_length,
+                stop,
+                generation_config=generation_config,
+                criterion=self.criterion,
+                exit_threshold=self.exit_threshold,
+                continuous_compute=self.continuous_compute,
+                exit_evaluator=self.exit_evaluator,
+                prefill_with_varied_exit_steps=self.prefill_with_varied_exit_steps,
+                **generation_kwargs,
+            )
         # Capture compute_steps if available
         if isinstance(output, GenerateDecoderOnlyOutput):
             compute_steps = [[] for _ in range(self.batch_size)]  # type: ignore
@@ -197,27 +205,31 @@ class HuginnWrapper(HFLM):
             return output.logits
 
 
-def evaluate_single_task(
-    task_name="gsm8k",
+def evaluate_tasks(
+    tasks = ["gsm8k"],
     model: Union[str, RavenForCausalLM] = "tomg-group-umd/huginn-0125",
     device="cuda",
-    batch_size=16,
+    batch_size=1,
     num_fewshot=5,
     limit=None,
-    criterion: Optional[Literal["entropy-diff", "latent-diff", "minp-kl", "argmax-stability", "none"]] = "entropy-diff",
-    exit_threshold: Optional[Union[str, float, int]] = "auto",
+    criterion: Literal["entropy-diff", "latent-diff", "minp-kl", "argmax-stability", "none"] = "entropy-diff",
+    exit_threshold: Union[str, float, int] = "auto",
     num_steps=32,
     lookup_strategy="full",
     exit_evaluator: Optional[PerIterationExitEvaluator] = None,
     continuous_compute=False,
     max_length=2048,
-    output_filepath: Optional[str] = None,
-    system_instruction: Optional[str] = None,
+    output_path: Optional[str] = None,
     prefill_with_varied_exit_steps: bool = False,
+    gen_kwargs: Optional[str] = "",
+    **kwargs,
 ):
     model_name = model if isinstance(model, str) else "custom_model"
+    if gen_kwargs is None:
+        gen_kwargs = ""
+
     config_args = {
-        "task_name": task_name,
+        "tasks": tasks,
         "model_name": model_name,
         "device": device,
         "batch_size": batch_size,
@@ -228,12 +240,13 @@ def evaluate_single_task(
         "exit_threshold": exit_threshold,
         "num_steps": num_steps,
         "lookup_strategy": lookup_strategy,
-        "system_instruction": system_instruction,
         "exit_evaluator": exit_evaluator.__class__.__name__ if exit_evaluator is not None else None,
         "prefill_with_varied_exit_steps": prefill_with_varied_exit_steps,
+        "gen_kwargs": gen_kwargs,
+        **kwargs,
     }
 
-    print(f"Evaluating {model_name} on {task_name} with config: {config_args}")
+    print(f"Evaluating {model_name} on {tasks} with config: {config_args}")
     model_wrapper = HuginnWrapper(
         pretrained=model,
         device=device,
@@ -243,18 +256,17 @@ def evaluate_single_task(
         dtype="bfloat16",
         criterion=criterion,
         exit_threshold=exit_threshold,
-        lookup_strategy=lookup_strategy,
         continuous_compute=continuous_compute,
         exit_evaluator=exit_evaluator,
         prefill_with_varied_exit_steps=prefill_with_varied_exit_steps,
     )
     results = evaluator.simple_evaluate(
         model=model_wrapper,
-        tasks=[task_name],
+        tasks=tasks,
         num_fewshot=num_fewshot,
         limit=limit,
-        system_instruction=system_instruction,
-        gen_kwargs=f"num_steps={num_steps}",
+        gen_kwargs=f"num_steps={num_steps},cache_lookup_strategy={lookup_strategy}," + gen_kwargs,
+        **kwargs,
     )
 
     if results is not None:
@@ -263,85 +275,91 @@ def evaluate_single_task(
         if hasattr(model_wrapper, "compute_steps") and model_wrapper.compute_steps:
             results["compute_steps"] = model_wrapper.compute_steps
 
-        if output_filepath is not None:
-            prepare_results(results, Path(output_filepath))
-        else:
-            prepare_results(results, Path(f"{task_name}_results.json"))
+        now = datetime.now()
+        timestamp = now.strftime("%Y-%m-%dT%H-%M-%S.%f")
+        model_pathname = model_name.replace("/", "__")
+        directory_path = Path(output_path, model_pathname) if output_path is not None else Path(model_pathname)
+        os.makedirs(directory_path, exist_ok=True)
+        prepare_results(results, Path(directory_path, f"hf_eval_results_{timestamp}.json"))
     return results
 
 
 if __name__ == "__main__":
     import argparse
+    from lm_eval.__main__ import setup_parser
+    parser: argparse.ArgumentParser = setup_parser()
+    parser.description = "lm_eval wrapper for evaluating Huginn on a task with adaptive compute."
 
-    parser = argparse.ArgumentParser(description="Evaluate a model on a task with adaptive compute.")
-    parser.add_argument("--task-name", dest="task_name", type=str, default="gsm8k", help="Task to evaluate on")
-    parser.add_argument(
-        "--model-name", dest="model_name", type=str, default="tomg-group-umd/huginn-0125", help="Model to evaluate"
-    )
-    parser.add_argument("--device", type=str, default="cuda", help="Device to run on (cuda, cpu)")
-    parser.add_argument("--batch-size", dest="batch_size", type=int, default=1, help="Batch size for evaluation")
-    parser.add_argument("--max-length", dest="max_length", type=int, default=2048, help="Max length for generation")
-    parser.add_argument("--num-fewshot", dest="num_fewshot", type=int, default=5, help="Number of few-shot examples")
-    parser.add_argument("--limit", type=int, default=None, help="Limit number of examples to evaluate")
+    # drop args that are not supported by our script
+    drop_args = [("model", "m"), ("model_args", "a"), "show_config", "include_path", "wandb_args", "hf_hub_log_args", "trust_remote_code"]
+    for drop_arg in drop_args:
+        if isinstance(drop_arg, tuple):
+            drop_arg, drop_arg_short = drop_arg
+        else:
+            drop_arg_short = None
+        parser._remove_action(parser._option_string_actions[f"--{drop_arg}"])
+        parser._option_string_actions.pop(f"--{drop_arg}")
+        if drop_arg_short is not None:
+            parser._option_string_actions.pop(f"-{drop_arg_short}")
+
     parser.add_argument(
         "--criterion",
         type=str,
-        default="entropy-diff",
-        choices=["entropy-diff", "latent-diff", "minp-kl", "argmax-stability", "none"],
+        default=SupportedExitCriteria.ENTROPY_DIFF.value,
+        choices=[c.value for c in SupportedExitCriteria],
         help="Criterion for adaptive compute. Pass `none` to disable adaptive compute.",
     )
     parser.add_argument(
-        "--exit-threshold",
-        dest="exit_threshold",
+        "--exit_threshold",
         type=str,
         default="auto",
         help="Exit threshold for adaptive compute. Pass `none` to disable adaptive compute.",
     )
-    parser.add_argument("--num-steps", dest="num_steps", type=int, default=32, help="Number of steps for generation")
+    parser.add_argument("--num_steps", type=int, default=32, help="Number of steps for generation")
     parser.add_argument(
-        "--lookup-strategy",
-        dest="lookup_strategy",
+        "--lookup_strategy",
         type=str,
         default="full",
         help="Lookup strategy for caching, also supports values like `compression-s4`",
     )
     parser.add_argument(
-        "--continuous-compute", dest="continuous_compute", type=bool, default=False, help="Continuous compute"
+        "--continuous_compute", type=bool, default=False, help="Continuous compute"
     )
+    parser.add_argument("--prefill_with_varied_exit_steps", type=bool, default=False, help="Prefill with varied exit steps")
+
+    # remove log_samples and re-register it with a different default value
+    parser._remove_action(parser._option_string_actions["--log_samples"])
+    parser._option_string_actions.pop("--log_samples")
+    parser._option_string_actions.pop("-s")
     parser.add_argument(
-        "--system-instruction", dest="system_instruction", type=str, default=None, help="System instruction"
-    )
-    parser.add_argument("--output-filepath", dest="output_filepath", type=str, default=None, help="Output filepath")
-    parser.add_argument(
-        "--prefill-with-varied-exit-steps",
-        dest="prefill_with_varied_exit_steps",
-        type=bool,
-        default=False,
-        help="Prefill with varied exit steps",
+        "--log_samples",
+        "-s",
+        action="store_true",
+        default=True,
+        help="If True, write out all model outputs and documents for per-sample measurement and post-hoc analysis.",
     )
 
     args = parser.parse_args()
 
-    # Try to convert exit_threshold to float if it's numeric
-    exit_threshold = None if args.exit_threshold == "none" else args.exit_threshold
-    if exit_threshold != "auto" and exit_threshold is not None:
-        with contextlib.suppress(ValueError):
-            exit_threshold = float(exit_threshold)  # Keep as string if not convertible to float
+    if args.batch_size != 1 and args.criterion != SupportedExitCriteria.NONE.value:
+        print(f"WARNING: please run adaptive compute with batch_size=1 if accurate results are desired.")
 
-    results = evaluate_single_task(
-        task_name=args.task_name,
-        model=args.model_name,
-        device=args.device,
-        batch_size=args.batch_size,
-        max_length=args.max_length,
-        num_fewshot=args.num_fewshot,
-        limit=args.limit,
-        criterion=args.criterion,
-        exit_threshold=exit_threshold,
-        num_steps=args.num_steps,
-        lookup_strategy=args.lookup_strategy,
-        continuous_compute=args.continuous_compute,
-        system_instruction=args.system_instruction,
-        output_filepath=args.output_filepath,
-        prefill_with_varied_exit_steps=args.prefill_with_varied_exit_steps,
+    # Try to convert exit_threshold to float if it's numeric
+    if args.exit_threshold != "auto" and args.exit_threshold != "none":
+        with contextlib.suppress(ValueError):
+            args.exit_threshold = float(args.exit_threshold)  # Keep as string if not convertible to float
+
+    if args.device is None:
+        args.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    seeds = args.seed
+    delattr(args, "seed")
+
+    results = evaluate_tasks(
+        model="tomg-group-umd/huginn-0125",
+        random_seed=seeds[0],
+        numpy_random_seed=seeds[1],
+        torch_random_seed=seeds[2],
+        fewshot_random_seed=seeds[3],
+        **vars(args)
     )

--- a/recpre/raven_modeling_minimal.py
+++ b/recpre/raven_modeling_minimal.py
@@ -10,6 +10,8 @@ from torch.utils.checkpoint import checkpoint
 from dataclasses import dataclass
 from typing import Union, Optional, Any, Tuple, Callable, List
 from functools import cache, cached_property
+from packaging import version
+import transformers
 
 from .raven_config_minimal import RavenConfig
 from transformers.cache_utils import Cache, DynamicCache, StaticCache
@@ -1152,7 +1154,10 @@ class RavenForCausalLM(RavenPreTrainedModel, GenerationMixin):
                 lookup_strategy=cache_lookup_strategy,
             )
         model_kwargs["use_cache"] = True
-        model_kwargs = self._get_initial_cache_position(input_ids.shape[1], input_ids.device, model_kwargs)
+        if version.parse(transformers.__version__) < version.parse("4.52.0"):
+            model_kwargs = self._get_initial_cache_position(input_ids, model_kwargs)
+        else:
+            model_kwargs = self._get_initial_cache_position(input_ids.shape[1], input_ids.device, model_kwargs)
         return model_kwargs, generation_config, max_new_tokens
 
     @torch.no_grad()
@@ -1240,6 +1245,7 @@ class RavenForCausalLM(RavenPreTrainedModel, GenerationMixin):
         min_steps: int = 0,
         check_criterion_every_n_steps=1,
         exit_evaluator: "Optional[PerIterationExitEvaluator]" = None,  # optional plugin of a new exit eval object
+        prefill_with_varied_exit_steps: bool = False,
         **model_kwargs,
     ) -> Union[torch.Tensor, GenerateDecoderOnlyOutput]:
         """
@@ -1271,6 +1277,20 @@ class RavenForCausalLM(RavenPreTrainedModel, GenerationMixin):
 
         if exit_evaluator is None:
             exit_evaluator = get_adaptive_exit_evaluator(self, criterion, exit_threshold)
+
+        if prefill_with_varied_exit_steps:
+            model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
+            output_logits, model_kwargs["past_key_values"], _ = self._prefill_with_varied_exit_steps(model_inputs["input_ids"], exit_evaluator, model_kwargs["past_key_values"], init_scale)
+            next_token_logits = output_logits[:, -1, :].to(**logit_type)  # type: ignore
+            next_token = self._sample_next_token(next_token_logits, generation_config)
+            input_ids = torch.cat([input_ids, next_token], dim=-1)
+            model_kwargs = self._update_model_kwargs_for_generation(
+                CausalLMOutputRecurrentLatents(
+                    past_key_values=model_kwargs["past_key_values"],
+                ),
+                model_kwargs,
+            )
+            max_new_tokens -= 1
 
         # Generate tokens
         for token_step_in_sequence in range(max_new_tokens):


### PR DESCRIPTION
As title, add option prefill_with_varied_exit_steps to enable adaptive prefilling for generate_with_adaptive_compute. The actual prefilling has been introduced earlier, and this commit just adds an option to toggle it.

Also some minor updates to lm_eval wrapper script, fixed a few issues after the recent refactor.